### PR TITLE
installed express package because it was saying it wasn't installed?

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "purrmanenthomes",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "concurrently": "^8.2.2"


### PR DESCRIPTION
ran npm i express because I was getting the error "cannot find module 'express'" even after running npm i. no more error message after the installation 